### PR TITLE
Remove spaces from the location field in Edit Structure dialog to adh…

### DIFF
--- a/src/net/sf/genomeview/gui/dialog/EditFeatureWindow.java
+++ b/src/net/sf/genomeview/gui/dialog/EditFeatureWindow.java
@@ -249,7 +249,7 @@ public class EditFeatureWindow extends JDialog {
 
 	private String format(Location[] loc) {
 		StringBuffer tmp = new StringBuffer(Arrays.toString(loc));
-		return tmp.substring(1, tmp.length() - 1);
+		return tmp.substring(1, tmp.length() - 1).replaceAll("\\s+", "");
 	}
 
 }


### PR DESCRIPTION
to adhere to EMBL syntax. Also lets the displayed location match the way it is stored in the Orcae database.